### PR TITLE
Show actions as grid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -4,6 +4,54 @@
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
+    "node_modules/@inquirer/core": {
+      "version": "10.1.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.11.tgz",
+      "integrity": "sha512-BXwI/MCqdtAhzNQlBEFE7CEflhPkl/BqvAuV/aK6lW3DClIfYVDWPP/kXuXHtBWC7/EEbNqd/1BGq2BGBBnuxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/figures": "^1.0.11",
+        "@inquirer/type": "^3.0.6",
+        "ansi-escapes": "^4.3.2",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@inquirer/figures": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.11.tgz",
@@ -11,6 +59,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.6.tgz",
+      "integrity": "sha512-/mKVCtVpyBu3IDarv0G+59KC4stsD5mDsGpYh+GKs1NZT88Jh52+cuoA1AtLk2Q0r/quNl+1cSUyLRHBFeD0XA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@kwsites/file-exists": {
@@ -43,7 +108,7 @@
       "version": "22.15.21",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.21.tgz",
       "integrity": "sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -686,7 +751,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/util-deprecate": {

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -28,6 +28,37 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
       "license": "MIT"
     },
+    "node_modules/@types/inquirer": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-9.0.8.tgz",
+      "integrity": "sha512-CgPD5kFGWsb8HJ5K7rfWlifao87m4ph8uioU7OTncJevmE/VLIqAAjfQtko578JZg7/f69K4FgqYym3gNr7DeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/through": "*",
+        "rxjs": "^7.2.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.15.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.21.tgz",
+      "integrity": "sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/through": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.33.tgz",
+      "integrity": "sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -636,6 +667,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,11 @@
         "chalk": "^5.0.0",
         "inquirer": "^9.0.0",
         "simple-git": "^3.16.0"
+      },
+      "devDependencies": {
+        "@types/inquirer": "^9.0.8",
+        "@types/node": "^22.15.21",
+        "typescript": "^5.8.3"
       }
     },
     "node_modules/@inquirer/figures": {
@@ -37,6 +42,37 @@
       "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
       "license": "MIT"
+    },
+    "node_modules/@types/inquirer": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-9.0.8.tgz",
+      "integrity": "sha512-CgPD5kFGWsb8HJ5K7rfWlifao87m4ph8uioU7OTncJevmE/VLIqAAjfQtko578JZg7/f69K4FgqYym3gNr7DeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/through": "*",
+        "rxjs": "^7.2.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.15.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.21.tgz",
+      "integrity": "sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/through": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.33.tgz",
+      "integrity": "sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -646,6 +682,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@inquirer/core": "^10.1.11",
         "chalk": "^5.0.0",
         "inquirer": "^9.0.0",
         "simple-git": "^3.16.0"
@@ -19,6 +20,54 @@
         "typescript": "^5.8.3"
       }
     },
+    "node_modules/@inquirer/core": {
+      "version": "10.1.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.11.tgz",
+      "integrity": "sha512-BXwI/MCqdtAhzNQlBEFE7CEflhPkl/BqvAuV/aK6lW3DClIfYVDWPP/kXuXHtBWC7/EEbNqd/1BGq2BGBBnuxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/figures": "^1.0.11",
+        "@inquirer/type": "^3.0.6",
+        "ansi-escapes": "^4.3.2",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@inquirer/figures": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.11.tgz",
@@ -26,6 +75,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.6.tgz",
+      "integrity": "sha512-/mKVCtVpyBu3IDarv0G+59KC4stsD5mDsGpYh+GKs1NZT88Jh52+cuoA1AtLk2Q0r/quNl+1cSUyLRHBFeD0XA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@kwsites/file-exists": {
@@ -58,7 +124,7 @@
       "version": "22.15.21",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.21.tgz",
       "integrity": "sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -701,7 +767,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "author": "Your Name",
   "license": "MIT",
   "dependencies": {
+    "@inquirer/core": "^10.1.11",
     "chalk": "^5.0.0",
     "inquirer": "^9.0.0",
     "simple-git": "^3.16.0"

--- a/package.json
+++ b/package.json
@@ -20,8 +20,13 @@
   "author": "Your Name",
   "license": "MIT",
   "dependencies": {
-    "inquirer": "^9.0.0",
     "chalk": "^5.0.0",
+    "inquirer": "^9.0.0",
     "simple-git": "^3.16.0"
+  },
+  "devDependencies": {
+    "@types/inquirer": "^9.0.8",
+    "@types/node": "^22.15.21",
+    "typescript": "^5.8.3"
   }
 }

--- a/src/git-ui.ts
+++ b/src/git-ui.ts
@@ -2,6 +2,7 @@
 import inquirer from 'inquirer';
 import simpleGit from 'simple-git';
 import chalk from 'chalk';
+import gitActions from './git/actionPrompt';
 
 const git = simpleGit();
 
@@ -15,30 +16,26 @@ async function mainMenu() {
     console.log(` - ${file.path} [${file.working_dir}${file.index}]`);
   });
 
-  const choices = [
-    { name: 'Stage all changes', value: 'stage_all' },
-    { name: 'Commit changes', value: 'commit' },
-    { name: 'Push to remote', value: 'push' },
-    { name: 'Pull from remote', value: 'pull' },
-    { name: 'Switch branch', value: 'switch_branch' },
-    { name: 'Show commit log', value: 'show_log' },
-    { name: 'Manage remotes', value: 'manage_remotes' },
-    { name: 'Create branch', value: 'create_branch' },
-    { name: 'Delete branch', value: 'delete_branch' },
-    { name: 'Show graph', value: 'graph' },
-    { name: 'Exit', value: 'exit' }
+  console.log('\n')
+  const actions = [
+    { name: 'Stage all changes', key: 'a', value: 'stage_all' },
+    { name: 'Commit changes', key: 'c', value: 'commit' },
+    { name: 'Push to remote', key: 'p', value: 'push' },
+    { name: 'Pull from remote', key: 'l', value: 'pull' },
+    { name: 'Switch branch', key: 's', value: 'switch_branch' },
+    { name: 'Show commit log', key: 'o', value: 'show_log' },
+    { name: 'Manage remotes', key: 'r', value: 'manage_remotes' },
+    { name: 'Create branch', key: 'b', value: 'create_branch' },
+    { name: 'Delete branch', key: 'd', value: 'delete_branch' },
+    { name: 'Show graph', key: 'g', value: 'graph' },
+    { name: 'Exit', key: 'x', value: 'exit' }
   ];
 
-  const answer = await inquirer.prompt([
-    {
-      type: 'list',
-      name: 'action',
-      message: 'Select an action',
-      choices
-    }
-  ]);
+  const action = await gitActions({
+    actions: actions
+  })
 
-  switch (answer.action) {
+  switch (action) {
     case 'stage_all':
       await git.add('.');
       console.log(chalk.green('All changes staged.'));

--- a/src/git-ui.ts
+++ b/src/git-ui.ts
@@ -19,7 +19,12 @@ async function mainMenu() {
 
   console.log('\n')
   const actions = [
-    { name: 'Stage all changes', key: 'a', value: 'stage_all' },
+    { name: 'Stage all changes', key: 'a', value: 'stage_all', subActions: [
+      { name: 'Stage all', value: 'stage_all' },
+      { name: 'Unstage all', value: 'unstage_all' },
+      { name: 'Stage file', value: 'stage_file' },
+      { name: 'Unstage file', value: 'unstage_file' }
+    ] },
     { name: 'Commit changes', key: 'c', value: 'commit' },
     { name: 'Push to remote', key: 'p', value: 'push' },
     { name: 'Pull from remote', key: 'l', value: 'pull' },

--- a/src/git-ui.ts
+++ b/src/git-ui.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env npx ts-node
 import inquirer from 'inquirer';
 import simpleGit from 'simple-git';
 import chalk from 'chalk';

--- a/src/git-ui.ts
+++ b/src/git-ui.ts
@@ -67,8 +67,13 @@ async function mainMenu() {
           ])
           if (answer.publish) {
             const status = await git.status();
-            await git.push(['--set-upstream', 'origin', status.current]);
-            console.log(chalk.green(`Branch ${status.current} published`))
+            if (status.current) {
+              await git.push(['--set-upstream', 'origin', status.current]);
+              console.log(chalk.green(`Branch ${status.current} published`))
+            }
+            else {
+              console.log(chalk.red('No current branch found.'));
+            }
           }
         }
         else {
@@ -199,16 +204,19 @@ async function manageRemotes() {
   }
 }
 
-async function createBranch(name) {
+async function createBranch(name: string) {
   try {
-    await git.checkoutBranch(name, (await git.status()).current)
+    const status = await git.status();
+    if (status.current) {
+      await git.checkoutBranch(name, status.current)
+    }
   }
   catch (error) {
     console.log(chalk.red(`Error creating branch ${name}: ${error}`))
   }
 }
 
-async function deleteBranch(name) {
+async function deleteBranch(name: string) {
   try {
     await git.deleteLocalBranch(name)
   }

--- a/src/git-ui.ts
+++ b/src/git-ui.ts
@@ -3,6 +3,7 @@ import inquirer from 'inquirer';
 import simpleGit from 'simple-git';
 import chalk from 'chalk';
 import gitActions from './git/actionPrompt';
+import stashPrompt from './git/stashPrompt';
 
 const git = simpleGit();
 
@@ -28,6 +29,7 @@ async function mainMenu() {
     { name: 'Create branch', key: 'b', value: 'create_branch' },
     { name: 'Delete branch', key: 'd', value: 'delete_branch' },
     { name: 'Show graph', key: 'g', value: 'graph' },
+    { name: 'Manage stashes', key: 't', value: 'stash' },
     { name: 'Exit', key: 'x', value: 'exit' }
   ];
 
@@ -125,6 +127,9 @@ async function mainMenu() {
       break;
     case 'graph':
       console.log(await git.raw(['log', '--graph', '--oneline', '--all']));
+      break;
+    case 'stash':
+      await stashPrompt(git);
       break;
     case 'exit':
       console.log('Goodbye!');

--- a/src/git/actionPrompt.ts
+++ b/src/git/actionPrompt.ts
@@ -1,10 +1,12 @@
 import { createPrompt, useKeypress, useState } from '@inquirer/core'
 import useTerminalSize from './useTerminalSize'
+import inquirer from 'inquirer'
 
 interface GitAction {
   name: string
   key?: string
   value: string
+  subActions?: GitAction[]
 }
 
 // Set your box size here
@@ -15,6 +17,7 @@ const bel = () => process.stdout.write("\x07")
 
 const gitActions = createPrompt((config: { actions: GitAction[], keys?: 'number' | 'letter' }, done) => {
   const [position, setPosition] = useState([0, 0])
+  const [selectSubActionIndex, setSelectSubActionIndex] = useState(-1)
 
   const { width, height } = useTerminalSize()
 
@@ -35,7 +38,7 @@ const gitActions = createPrompt((config: { actions: GitAction[], keys?: 'number'
       }
     })
   }
-  
+
   // Build the grid: array of arrays of GitActions
   const grid: GitAction[][] = []
   for (let r = 0; r < rows; r++) {
@@ -44,33 +47,72 @@ const gitActions = createPrompt((config: { actions: GitAction[], keys?: 'number'
     grid.push(config.actions.slice(start, end))
   }
 
-  useKeypress((key) => {
-    if (key.name === 'up') {
-      setPosition([Math.max(0, position[0] - 1), position[1]])
-    }
-    else if (key.name === 'down') {
-      if (grid[Math.min(grid.length - 1, position[0] + 1)][position[1]]) {
-        setPosition([Math.min(grid.length - 1, position[0] + 1), position[1]])
+  useKeypress(async (key) => {
+    if (selectSubActionIndex !== -1) {
+      // If a subAction is selected, handle its navigation
+      if (key.name === 'up') {
+        setSelectSubActionIndex(Math.max(0, selectSubActionIndex - 1))
       }
-    }
-    else if (key.name === 'left') {
-      setPosition([position[0], Math.max(0, position[1] - 1)])
-    }
-    else if (key.name === 'right') {
-      setPosition([position[0], Math.min(grid[position[0]].length - 1, position[1] + 1)])
-    }
-    else if (key.name === 'return') {
-      const action = grid[position[0]][position[1]]
-      if (action) {
-        done(action.value)
+      else if (key.name === 'down') {
+        setSelectSubActionIndex(Math.min(grid[position[0]][position[1]].subActions!.length - 1, selectSubActionIndex + 1))
       }
-    }
-    else {
-      const actionWithKey = config.actions.find(a => a.key && a.key.toLowerCase() === key.name)
-      if (actionWithKey) {
-        done(actionWithKey.value)
-      } else {
-        bel()
+      //@ts-expect-error meta is not defined in type but exists in the event
+      else if (key.name === 'return' && !key.meta) {
+        const action = grid[position[0]][position[1]].subActions?.[selectSubActionIndex]
+        if (action) {
+          done(action.value)
+        }
+      }
+      else if (key.name === 'escape' || key.name === 'backspace') { // Escape is uncomfortable since it is not handled immediately
+        setSelectSubActionIndex(-1)
+      }
+      else {
+        const actionWithKey = grid[position[0]][position[1]].subActions?.find(a => a.key && a.key.toLowerCase() === key.name)
+        if (actionWithKey) {
+          done(actionWithKey.value)
+        } else {
+          bel()
+        }
+      }
+    } else {
+      if (key.name === 'up') {
+        setPosition([Math.max(0, position[0] - 1), position[1]])
+      }
+      else if (key.name === 'down') {
+        if (grid[Math.min(grid.length - 1, position[0] + 1)][position[1]]) {
+          setPosition([Math.min(grid.length - 1, position[0] + 1), position[1]])
+        }
+      }
+      else if (key.name === 'left') {
+        setPosition([position[0], Math.max(0, position[1] - 1)])
+      }
+      else if (key.name === 'right') {
+        setPosition([position[0], Math.min(grid[position[0]].length - 1, position[1] + 1)])
+      }
+      else if (key.name === 'return') {
+        //@ts-expect-error meta is not defined in type but exists in the event
+        if (key.meta) {
+          if (grid[position[0]][position[1]].subActions) {
+            setSelectSubActionIndex(0)
+          }
+          else {
+            bel()
+          }
+        }
+        else {
+          const action = grid[position[0]][position[1]]
+          if (action) {
+            done(action.value)
+          }
+        }
+      }
+      else {
+        const actionWithKey = config.actions.find(a => a.key && a.key.toLowerCase() === key.name)
+        if (actionWithKey) {
+          done(actionWithKey.value)
+        } else {
+          bel()
+        }
       }
     }
   })
@@ -83,7 +125,7 @@ const gitActions = createPrompt((config: { actions: GitAction[], keys?: 'number'
     for (let c = 0; c < cols; c++) {
       const action = grid[r][c]
       const isSelected = r === position[0] && c === position[1]
-      boxes.push(renderActionBox(action, isSelected, ACTION_WIDTH, ACTION_HEIGHT))
+      boxes.push(renderActionBox(action, isSelected, selectSubActionIndex, ACTION_WIDTH, ACTION_HEIGHT))
     }
     // Render each line of the boxes in this row
     for (let line = 0; line < ACTION_HEIGHT; line++) {
@@ -95,15 +137,17 @@ const gitActions = createPrompt((config: { actions: GitAction[], keys?: 'number'
     }
   }
 
-  output += '\nUse arrow keys to navigate and Enter or the action key to select.'
+  output += selectSubActionIndex === -1 ? '\nUse arrow keys to navigate and Enter or the action key to select.' : '\nUse arrow keys to select sub action or backspace to exit'
 
   return output
 })
 
 export default gitActions;
+
 function renderActionBox(
   action: GitAction | undefined,
   isSelected: boolean,
+  selectSubActionIndex: number = -1,
   width: number,
   height: number
 ): string[] {
@@ -122,6 +166,47 @@ function renderActionBox(
   // Top and bottom borders
   lines[0] = '┌' + '─'.repeat(width - 2) + '┐'
   lines[height - 1] = '└' + '─'.repeat(width - 2) + '┘'
+
+  // If subActions are being selected, render them as a list
+  if (selectSubActionIndex !== -1 && action.subActions && action.subActions.length > 0) {
+    const visibleCount = height - 2
+    const visibleLength = width - 4 // 2 for borders, 2 for padding
+    let start = 0
+    // Scroll if needed
+    if (selectSubActionIndex >= visibleCount) {
+      start = selectSubActionIndex - visibleCount + 1
+    }
+    const subActionsToShow = action.subActions.slice(start, start + visibleCount)
+    // Inverse border
+    lines[0] = '\x1b[7m' + lines[0] + '\x1b[0m'
+    lines[height - 1] = '\x1b[7m' + lines[height - 1] + '\x1b[0m'
+    for (let i = 1; i < height - 1; i++) {
+      const subAction = subActionsToShow[i - 1]
+      let content = ''
+      if (subAction) {
+        content = subAction.name.slice(0, visibleLength)
+        if (subAction.key) {
+          content = `[${subAction.key.toUpperCase()}] ${content.slice(subAction.key.length + 4)}`
+        }
+        // Reverse: highlight all except the selected subAction
+        if (start + i - 1 !== selectSubActionIndex) {
+          content = `\x1b[7m${content.padEnd(width - 4)}\x1b[0m`
+        } else {
+          content = content.padEnd(width - 4)
+        }
+      } else {
+        content = ''.padEnd(width - 4)
+        content = `\x1b[7m${content}\x1b[0m`
+      }
+      if (start + i - 1 === selectSubActionIndex) {
+        lines[i] = '\x1b[7m│\x1b[0m ' + content + ' \x1b[7m│\x1b[0m'
+      }
+      else {
+        lines[i] = '\x1b[7m│ \x1b[0m' + content + '\x1b[7m │\x1b[0m'
+      }
+    }
+    return lines
+  }
 
   // Word wrapping with ' ' as separator and 1 space padding on both sides
   const wrapWidth = width - 4 // 2 for borders, 2 for padding
@@ -157,6 +242,10 @@ function renderActionBox(
       content = ' '.repeat(padLeft) + content + ' '.repeat(padRight)
     }
     lines[i] = '│ ' + content + ' │'
+  }
+
+  if (action.subActions) {
+    lines[height - 2] = lines[height - 2].slice(0, width - 2) + '*│'
   }
 
   // Highlight if selected

--- a/src/git/actionPrompt.ts
+++ b/src/git/actionPrompt.ts
@@ -12,7 +12,8 @@ const ACTION_HEIGHT = 8
 const ACTION_WIDTH = 16
 
 const bel = () => process.stdout.write("\x07")
-const gitActions = createPrompt((config: { actions: GitAction[] }, done) => {
+
+const gitActions = createPrompt((config: { actions: GitAction[], keys?: 'number' | 'letter' }, done) => {
   const [position, setPosition] = useState([0, 0])
 
   const { width, height } = useTerminalSize()
@@ -21,6 +22,20 @@ const gitActions = createPrompt((config: { actions: GitAction[] }, done) => {
   const cols = Math.max(1, Math.floor(width / ACTION_WIDTH))
   const rows = Math.ceil(config.actions.length / cols)
 
+  if (config.keys === 'number') {
+    config.actions.forEach((action, index) => {
+      if (index <= 9) {
+        action.key = ((index + 1) % 10).toString()
+      }
+    })
+  } else if (config.keys === 'letter') {
+    config.actions.forEach((action, index) => {
+      if (index <= 25) {
+        action.key = String.fromCharCode(97 + index) // 'a' is 97 in ASCII
+      }
+    })
+  }
+  
   // Build the grid: array of arrays of GitActions
   const grid: GitAction[][] = []
   for (let r = 0; r < rows; r++) {

--- a/src/git/actionPrompt.ts
+++ b/src/git/actionPrompt.ts
@@ -1,0 +1,155 @@
+import { createPrompt, useKeypress, useState } from '@inquirer/core'
+import useTerminalSize from './useTerminalSize'
+
+interface GitAction {
+  name: string
+  key?: string
+  value: string
+}
+
+// Set your box size here
+const ACTION_HEIGHT = 8
+const ACTION_WIDTH = 16
+
+const bel = () => process.stdout.write("\x07")
+const gitActions = createPrompt((config: { actions: GitAction[] }, done) => {
+  const [position, setPosition] = useState([0, 0])
+
+  const { width, height } = useTerminalSize()
+
+  // Calculate number of columns and rows based on terminal size and action box size
+  const cols = Math.max(1, Math.floor(width / ACTION_WIDTH))
+  const rows = Math.ceil(config.actions.length / cols)
+
+  // Build the grid: array of arrays of GitActions
+  const grid: GitAction[][] = []
+  for (let r = 0; r < rows; r++) {
+    const start = r * cols
+    const end = start + cols
+    grid.push(config.actions.slice(start, end))
+  }
+
+  useKeypress((key) => {
+    if (key.name === 'up') {
+      setPosition([Math.max(0, position[0] - 1), position[1]])
+    }
+    else if (key.name === 'down') {
+      if (grid[Math.min(grid.length - 1, position[0] + 1)][position[1]]) {
+        setPosition([Math.min(grid.length - 1, position[0] + 1), position[1]])
+      }
+    }
+    else if (key.name === 'left') {
+      setPosition([position[0], Math.max(0, position[1] - 1)])
+    }
+    else if (key.name === 'right') {
+      setPosition([position[0], Math.min(grid[position[0]].length - 1, position[1] + 1)])
+    }
+    else if (key.name === 'return') {
+      const action = grid[position[0]][position[1]]
+      if (action) {
+        done(action.value)
+      }
+    }
+    else {
+      const actionWithKey = config.actions.find(a => a.key && a.key.toLowerCase() === key.name)
+      if (actionWithKey) {
+        done(actionWithKey.value)
+      } else {
+        bel()
+      }
+    }
+  })
+
+  let output = ''
+
+  for (let r = 0; r < rows; r++) {
+    // Prepare all boxes for this row
+    const boxes: string[][] = []
+    for (let c = 0; c < cols; c++) {
+      const action = grid[r][c]
+      const isSelected = r === position[0] && c === position[1]
+      boxes.push(renderActionBox(action, isSelected, ACTION_WIDTH, ACTION_HEIGHT))
+    }
+    // Render each line of the boxes in this row
+    for (let line = 0; line < ACTION_HEIGHT; line++) {
+      let rowLine = ''
+      for (let c = 0; c < cols; c++) {
+        rowLine += boxes[c][line]
+      }
+      output += rowLine + '\n'
+    }
+  }
+
+  output += '\nUse arrow keys to navigate and Enter or the action key to select.'
+
+  return output
+})
+
+export default gitActions;
+function renderActionBox(
+  action: GitAction | undefined,
+  isSelected: boolean,
+  width: number,
+  height: number
+): string[] {
+  const lines = Array(height).fill(' '.repeat(width))
+
+  if (!action) {
+    // Empty box
+    lines[0] = '┌' + '─'.repeat(width - 2) + '┐'
+    lines[height - 1] = '└' + '─'.repeat(width - 2) + '┘'
+    for (let i = 1; i < height - 1; i++) {
+      lines[i] = '│' + ' '.repeat(width - 2) + '│'
+    }
+    return lines
+  }
+
+  // Top and bottom borders
+  lines[0] = '┌' + '─'.repeat(width - 2) + '┐'
+  lines[height - 1] = '└' + '─'.repeat(width - 2) + '┘'
+
+  // Word wrapping with ' ' as separator and 1 space padding on both sides
+  const wrapWidth = width - 4 // 2 for borders, 2 for padding
+  const words = action.name.split(' ')
+  let wrapped: string[] = []
+  let currentLine = ''
+
+  for (const word of words) {
+    if ((currentLine + (currentLine ? ' ' : '') + word).length > wrapWidth) {
+      wrapped.push(currentLine)
+      currentLine = word
+    } else {
+      currentLine += (currentLine ? ' ' : '') + word
+    }
+  }
+  if (currentLine) wrapped.push(currentLine)
+  wrapped = wrapped.slice(0, height - 2) // fit in box
+
+  // Fill lines 1..height-2 with wrapped content, centered, padded
+  for (let i = 1; i < height - 1; i++) {
+    let content = wrapped[i - 1] || ''
+    // On the 5th line (i == 4), if action.key, show key centered
+    if (i === 4 && action.key) {
+      const keyLabel = action.key.toUpperCase()
+      const pad = wrapWidth - keyLabel.length
+      const padLeft = Math.floor(pad / 2)
+      const padRight = pad - padLeft
+      content = ' '.repeat(padLeft) + keyLabel + ' '.repeat(padRight)
+    } else {
+      const pad = wrapWidth - content.length
+      const padLeft = Math.floor(pad / 2)
+      const padRight = pad - padLeft
+      content = ' '.repeat(padLeft) + content + ' '.repeat(padRight)
+    }
+    lines[i] = '│ ' + content + ' │'
+  }
+
+  // Highlight if selected
+  if (isSelected) {
+    for (let i = 0; i < height; i++) {
+      lines[i] = lines[i].replace(/./g, (ch: string) => `\x1b[7m${ch}\x1b[0m`)
+    }
+  }
+
+  return lines
+}

--- a/src/git/stashPrompt.ts
+++ b/src/git/stashPrompt.ts
@@ -1,0 +1,127 @@
+import { SimpleGit } from "simple-git";
+import gitActions from "./actionPrompt";
+import inquirer from "inquirer";
+import chalk from "chalk";
+
+async function selectStash(git: SimpleGit, message?: string): Promise<{ index: number; message: string; hash: string }> {
+  const stashes = await git.stashList();
+  if (stashes.all.length === 0) {
+    console.log(chalk.red('No stashes found.'));
+    return { index: -1, message: '', hash: '' };
+  }
+
+  const choices = stashes.all.map((stash: any, index: number) => ({
+    name: `${index}: ${stash.message} (${stash.hash})`,
+    value: { index, message: stash.message, hash: stash.hash }
+  }));
+
+  const { selectedStash } = await inquirer.prompt([
+    {
+      type: 'list',
+      name: 'selectedStash',
+      message: message ?? 'Select a stash:',
+      choices
+    }
+  ]);
+
+  return selectedStash;
+}
+export default async function stashPrompt(git: SimpleGit) {
+  const action = await gitActions({
+    actions: [
+      { value: 'save', name: 'Save Stash' },
+      { value: 'list', name: 'List Stashes' },
+      { value: 'apply', name: 'Apply Stash' },
+      { value: 'drop', name: 'Drop Stash' },
+      { value: 'pop', name: 'Pop Stash' },
+      { value: 'clear', name: 'Clear Stashes' },
+      { value: 'branch', name: 'Create Branch from Stash' },
+      { value: 'show', name: 'Show Stash' },
+      { value: 'back', name: 'Back' }
+    ],
+    keys: 'number'
+  })
+
+  switch (action) {
+    case 'save':
+      const { stashMessage } = await inquirer.prompt([
+        {
+          type: 'input',
+          name: 'stashMessage',
+          message: 'Enter stash message (optional):'
+        }
+      ])
+
+      if (stashMessage) {
+        await git.stash(['save', stashMessage]);
+        console.log(`Stash saved with message: ${stashMessage}`);
+      } else {
+        await git.stash(['save']);
+      }
+      console.log(chalk.green('Stash saved.'));
+      break;
+    case 'list':
+      const stashes = await git.stashList();
+      if (stashes.all.length === 0) {
+        console.log('No stashes found.');
+      }
+      else {
+        console.log('Stashes:');
+        stashes.all.forEach((stash, index) => {
+          console.log(`${index}: ${stash.message}`);
+        });
+      }
+      break;
+    case 'apply':
+      const applyStash = await selectStash(git, 'Select a stash to apply:');
+
+      await git.stash(['apply', `stash@{${applyStash.index}}`]);
+      console.log(chalk.green(`Stash applied: stash@{${applyStash.index}} (${applyStash.hash})`));
+      break;
+    case 'drop':
+      const { index, message, hash } = await selectStash(git, 'Select a stash to drop:');
+      if (index === -1) {
+        break;
+      }
+      await git.stash(['drop', `stash@{${index}}`]);
+      console.log(chalk.green(`Stash dropped: stash@{${index}} (${hash})` + message ? `: ${message}` : ''));
+
+      break;
+    case 'pop':
+      const popStash = await selectStash(git, 'Select a stash to pop:');
+      // Get the stash list before popping to retrieve the hash
+      await git.stash(['pop', `stash@{${popStash.index}}`]);
+        console.log(chalk.green(`Stash popped: stash@{${popStash.index}} (${popStash.hash})`));
+      break;
+    case 'clear':
+      await git.stash(['clear']);
+      console.log(chalk.green('All stashes cleared.'));
+      break;
+    case 'branch':
+      const branchStash = await selectStash(git, 'Select a stash to create a branch from:');
+      const { branchName } = await inquirer.prompt([
+        {
+          type: 'input',
+          name: 'branchName',
+          message: 'Enter the new branch name:'
+        }
+      ]);
+
+      await git.stash(['branch', branchName, `stash@{${branchStash.index}}`]);
+      console.log(chalk.green(`Branch created from stash: ${branchName}`));
+      break;
+    case 'show':
+      const showStash = await selectStash(git, 'Select a stash to show:');
+      const stashShow = await git.stash(['show', `stash@{${showStash.index}}`]);
+      if (stashShow) {
+        console.log(chalk.green(`Stash show: stash@{${showStash.index}}`));
+        console.log(stashShow);
+      } else {
+        console.log(chalk.red(`No stash found at index: ${showStash.index}`));
+      }
+      break;
+    case 'back':
+      console.log('Going back...');
+      return;
+  }
+}

--- a/src/git/stashPrompt.ts
+++ b/src/git/stashPrompt.ts
@@ -27,6 +27,8 @@ async function selectStash(git: SimpleGit, message?: string): Promise<{ index: n
   return selectedStash;
 }
 export default async function stashPrompt(git: SimpleGit) {
+  console.clear();
+  console.log(chalk.cyan('Stash Menu'));
   const action = await gitActions({
     actions: [
       { value: 'save', name: 'Save Stash' },

--- a/src/git/useTerminalSize.ts
+++ b/src/git/useTerminalSize.ts
@@ -1,0 +1,3 @@
+export default function useTerminalSize() {
+  return { width: process.stdout.columns, height: process.stdout.rows };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,113 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
+
+    /* Projects */
+    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+    /* Language and Environment */
+    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "libReplacement": true,                           /* Enable lib replacement. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+
+    /* Modules */
+    "module": "commonjs",                                /* Specify what module code is generated. */
+    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+    // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
+    // "rewriteRelativeImportExtensions": true,          /* Rewrite '.ts', '.tsx', '.mts', and '.cts' file extensions in relative import paths to their JavaScript equivalent in output files. */
+    // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
+    // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
+    // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
+    // "noUncheckedSideEffectImports": true,             /* Check side effect imports. */
+    // "resolveJsonModule": true,                        /* Enable importing .json files. */
+    // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
+    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+
+    /* JavaScript Support */
+    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+
+    /* Emit */
+    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    // "removeComments": true,                           /* Disable emitting comments. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
+    // "isolatedDeclarations": true,                     /* Require sufficient annotation on exports so other tools can trivially generate declaration files. */
+    // "erasableSyntaxOnly": true,                       /* Do not allow runtime constructs that are not part of ECMAScript. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+
+    /* Type Checking */
+    "strict": true,                                      /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "strictBuiltinIteratorReturn": true,              /* Built-in iterators are instantiated with a 'TReturn' type of 'undefined' instead of 'any'. */
+    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
+    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+  }
+}


### PR DESCRIPTION
The list of Git actions was very long and about to get even longer. It's not the best to scroll through it and search for an action every time.

This pull request replaces the inquirer menu with a custom grid showing all actions. Actions can be executed by selecting it with the arrow keys and pressing enter or by directly pressing the key assigned to the action, which makes the usage much easier.

The grid automatically adapts to the terminal width. I created the `useTerminalSize` hook for it (inquirer has a system to build custom prompts, including React-like hooks).

![New Crazy Git UI with action grid](https://github.com/user-attachments/assets/11b6eeca-57a0-40a8-8af7-3d5d5336240f)

There are additional possible improvements to this, for example allowing users to customize the grid or adding colors for better recognition.

---

Additional changes:
- Added a .gitignore file containing the node_modules.
- Switched git-ui to TypeScript for type safety and to make the code easier to understand.